### PR TITLE
Add Askey RT4230W REV6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ sh <(wget -O - https://raw.githubusercontent.com/itdoginfo/cpu-wrt-bench/refs/he
 | Xiaomi Mi Router AX3000T | MediaTek MT7981BA  | OpenWrt 24.10.1 | 2        | 291.67         | 10.89               | 581.33            | 19.86                  |
 | FriendlyElec NanoPi R3S | Rockchip RK3566 | OpenWrt 24.10.2 | 4            | 419.93         | 17.65               | 1652.03           | 51.48                    |
 | Xiaomi Redmi Router AX6000 | MediaTek MT7986A | OpenWrt 24.10.1 | 4        | 451.73         | 18.78               | 1805.96           | 55.30                  |
+| Askey RT4230W REV6      | Qualcomm IPQ8065 | OpenWrt 25.12.1 | 2            | 202.40         | 589.16              | 406.17            | 1094.37                |
 
 > [!NOTE]
 > n/s - CPU not supported int128 method.


### PR DESCRIPTION
I double checked the strong `matrixprod` results on OpenWrt 23.05 and 25.12 and on two of these devices.